### PR TITLE
Fixes parentheses in parameter descriptions

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -11,7 +11,7 @@ Calibrations related resources of the **fcdb-api**
 
 + Parameters
     + maxAge (optional, string) ... Maximum, i.e. oldest, calibration age in Ma.
-    + minAge (optional, string) ... Minimum, i.e. youngest calibration age in Ma.
+    + minAge (optional, string) ... Minimum, i.e. youngest, calibration age in Ma.
     + clade (optional, string) ... Name of taxon identifying clade in which to search
     + tipTaxa%5B%5D (optional, array) ... Up to 2 taxa to use when performing an MRCA search.
     + geologicalTime (optional, string) ... Geological time period

--- a/apiary.apib
+++ b/apiary.apib
@@ -10,8 +10,8 @@ Calibrations related resources of the **fcdb-api**
 ## Calibrations Collection [/calibrations{?.format}{?maxAge,minAge,clade,tipTaxa%5B%5D,geologicalTime}]
 
 + Parameters
-    + maxAge (optional, string) ... Maximum (oldest) calibration age in Ma.
-    + minAge (optional, string) ... Minimum (youngest) calibration age in Ma.
+    + maxAge (optional, string) ... Maximum, i.e. oldest, calibration age in Ma.
+    + minAge (optional, string) ... Minimum, i.e. youngest calibration age in Ma.
     + clade (optional, string) ... Name of taxon identifying clade in which to search
     + tipTaxa%5B%5D (optional, array) ... Up to 2 taxa to use when performing an MRCA search.
     + geologicalTime (optional, string) ... Geological time period


### PR DESCRIPTION
Apparently Apiary.io doesn't like these when rendering. It complains about a "semantic issue" in these lines, and leaves them out from the parameter table. This change fixes that.